### PR TITLE
Make electron reload optional

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# Install Node and Python dependencies
+npm ci
+

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ This launches both servers:
 - Frontend on port specified in `ports.ini` (default: `http://localhost:3000`)
 - Backend on port specified in `ports.ini` (default: `http://localhost:5000`)
 
+Fast reload for the Electron window is **disabled by default** to reduce CPU and
+memory usage. If you prefer automatic reloads during development, set
+`USE_ELECTRON_RELOAD=1` in your environment before running the above command.
+
 Press `Ctrl + C` to stop both.
 
 #### (B) Using Provided Batch/Shell Scripts


### PR DESCRIPTION
## Summary
- document optional Electron reload
- support `USE_ELECTRON_RELOAD` env var instead of always enabling reload
- add global error handlers for more robust Electron startup
- add Codex setup script to install dependencies

## Testing
- `node scripts/autotest.js` *(fails: Cannot find package 'node-fetch')*
- `npm run lint` *(fails: next: not found)*
