### PR TITLE
Add pytest-based backend tests

### DIFF
--- a/python_backend/controllers/resolve_folder_controller.py
+++ b/python_backend/controllers/resolve_folder_controller.py
@@ -11,6 +11,7 @@ from http import HTTPStatus
 from pathlib import Path
 
 from flask import Blueprint, jsonify, request, abort
+from typing import Optional
 
 from utils.path_utils import list_logical_drives, list_subfolders
 from repositories.file_storage import FileStorageRepository
@@ -36,7 +37,7 @@ def api_select_drives():
 # ───────────────────────── 2. browse sub‑folders ────────────────────────────
 @resolve_bp.get("/browse_folders")
 def api_browse_folders():
-    raw_path: str | None = request.args.get("path")
+    raw_path: Optional[str] = request.args.get("path")
     if not raw_path:
         abort(HTTPStatus.BAD_REQUEST, "Missing 'path' query‑param")
 

--- a/python_backend/services/autoselect_service.py
+++ b/python_backend/services/autoselect_service.py
@@ -327,7 +327,7 @@ class AutoselectService:
     # ───────────────────────────── json / path utils (same as before) ───────
     _FENCE_RE = re.compile(r"```(?:json)?\s*([\s\S]+?)\s*```", re.I)
 
-    def _extract_json(self, text: str) -> Any | None:
+    def _extract_json(self, text: str) -> Optional[Any]:
         cleaned = text.strip()
         m = self._FENCE_RE.search(cleaned)
         if m:

--- a/python_backend/services/codemap_service.py
+++ b/python_backend/services/codemap_service.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Set, Tuple, Optional, Union
 
 from tree_sitter import Node, Parser  # type: ignore
 from tree_sitter_languages import get_parser
@@ -249,13 +249,13 @@ class CodemapService:
 
     # ---------------------------------------------------------------- helpers
     @staticmethod
-    def _lang_for(path: str) -> str | None:
+    def _lang_for(path: str) -> Optional[str]:
         return _EXT_TO_LANG.get(os.path.splitext(path)[1].lower())
 
     def _error_stub(self, message: str) -> Dict[str, str]:
         return {"error": message}
 
-    def _extract_one(self, abs_path: str, rel: str) -> Dict[str, List[str] | str]:
+    def _extract_one(self, abs_path: str, rel: str) -> Dict[str, Union[List[str], str]]:
         lang = self._lang_for(abs_path)
         if not lang:
             # Unsupported *and* no txt fallback – silently ignore
@@ -296,13 +296,13 @@ class CodemapService:
     # ---------------------------------------------------------------- public
     def extract_codemap(
         self, base_dir: str, rel_paths: List[str]
-    ) -> Dict[str, Dict[str, List[str] | str]]:
+    ) -> Dict[str, Dict[str, Union[List[str], str]]]:
         if not os.path.isdir(base_dir):
             raise ValueError("base_dir must be an existing directory")
         if not isinstance(rel_paths, list):
             raise ValueError("rel_paths must be a list")
 
-        result: Dict[str, Dict[str, List[str] | str]] = {}
+        result: Dict[str, Dict[str, Union[List[str], str]]] = {}
         for rel in rel_paths:
             abs_path = os.path.join(base_dir, rel)
             if not os.path.isfile(abs_path):

--- a/python_backend/services/kanban_service.py
+++ b/python_backend/services/kanban_service.py
@@ -27,10 +27,10 @@ PriorityT = Literal["low", "medium", "high"]
 class KanbanItemModel(BaseModel):
     id:        int
     title:     str  = Field(min_length=1, max_length=256)
-    details:   str | None = None
+    details:   Optional[str] = None
     status:    StatusT    = "todo"
     priority:  PriorityT  = "medium"
-    dueDate:   str | None = None          # ISO-8601
+    dueDate:   Optional[str] = None          # ISO-8601
     createdAt: str
 
     # empty strings → None (prevents validation error on “clear”)

--- a/python_backend/tests/test_app_endpoints.py
+++ b/python_backend/tests/test_app_endpoints.py
@@ -1,0 +1,43 @@
+import os
+import sys
+from flask.testing import FlaskClient
+import pytest
+
+# Allow imports from the python_backend package when tests are run from the repo root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import create_app
+
+
+@pytest.fixture
+def client() -> FlaskClient:
+    app = create_app({"TESTING": True})
+    return app.test_client()
+
+
+def test_health(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "healthy"}
+
+
+def test_todo_crud(client):
+    # list todos
+    resp = client.get("/api/todos")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+
+    # add todo
+    resp = client.post("/api/todos", json={"text": "pytest item"})
+    assert resp.status_code == 201
+    new_id = resp.get_json()["data"]["id"]
+
+    # update
+    resp = client.put(f"/api/todos/{new_id}", json={"completed": True})
+    assert resp.status_code == 200
+    assert resp.get_json()["data"]["completed"] is True
+
+    # delete
+    resp = client.delete(f"/api/todos/{new_id}")
+    assert resp.status_code == 204

--- a/python_backend/tests/test_todo_service.py
+++ b/python_backend/tests/test_todo_service.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import pytest
+
+# Allow imports from the python_backend package when tests are run from the repo root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from services.todo_service import TodoService
+from repositories.file_storage import FileStorageRepository
+
+
+@pytest.fixture
+def todo_service():
+    repo = FileStorageRepository()
+    return TodoService(repo)
+
+
+def test_add_list_update_delete(todo_service):
+    # Initially returns at least the sample todo
+    initial = todo_service.list_todos(None)
+    assert isinstance(initial, list)
+    assert len(initial) >= 1
+
+    new = todo_service.add_todo("write tests", None)
+    assert new["text"] == "write tests"
+    new_id = new["id"]
+
+    updated = todo_service.update_todo(new_id, True, None)
+    assert updated is not None
+    assert updated["completed"] is True
+
+    assert todo_service.delete_todo(new_id, None) is True
+    remaining = [t for t in todo_service.list_todos(None) if t["id"] == new_id]
+    assert not remaining


### PR DESCRIPTION
## Summary
- create `python_backend/tests` with pytest suite
- test `TodoService` CRUD operations
- test Flask endpoints for health and todos
- fix type hints using Optional and Union for Python 3.9 compatibility

## Testing
- `python_backend/venv/bin/python -m pytest -q python_backend/tests`
