### PR TITLE
Fix GitHub CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,32 +35,20 @@ jobs:
         run: |
           python -m pytest -q python_backend/tests
 
-      # 5) Start the Python backend in the background
-      - name: Start Python Backend
-        run: |
-          nohup python python_backend/app.py &
-          sleep 5
-
-      # 6) Set up Node.js
+      # 5) Set up Node.js
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "20"
 
-      # 7) Install Node dependencies (CI-friendly)
+      # 6) Install Node dependencies (CI-friendly)
       - name: Install Node Dependencies
         run: npm ci
 
-      # 8) Build the Next.js app
+      # 7) Build the Next.js app
       - name: Build Next.js
         run: npm run build
 
-      # 9) Start Next.js in the background
-      - name: Start Next.js
-        run: |
-          nohup npm run start &
-          sleep 10
-
-      # 10) Run the auto-tests (Python + Next.js)
+      # 8) Run the auto-tests (Python + Next.js)
       - name: Run AutoTests
         run: node scripts/autotest.js


### PR DESCRIPTION
## Summary
- update CI to use Node 20
- remove pre-started servers to avoid port conflicts and run autotest directly

## Testing
- `python_backend/venv/bin/python -m pytest -q python_backend/tests`
- `node scripts/autotest.js`
